### PR TITLE
Error in the format of the ossec.conf files and command entries only …

### DIFF
--- a/wazuh/attributes/default.rb
+++ b/wazuh/attributes/default.rb
@@ -104,7 +104,7 @@ default['ossec']['ignore_failure'] = true
 end
 
 # Commands settings (common for both Manager and Agent)
-default['ossec']['conf']['all']['command'] = [
+default['ossec']['conf']['server']['command'] = [
 {
   'name' => 'host-deny',
   'executable' => 'host-deny.sh',

--- a/wazuh/libraries/helpers.rb
+++ b/wazuh/libraries/helpers.rb
@@ -55,7 +55,10 @@ class Chef
 
       def self.ossec_to_xml(hash)
         require 'gyoku'
-        Gyoku.xml object_to_ossec(hash)
+        require 'nokogiri'
+        source= Gyoku.xml object_to_ossec(hash)
+        doc = Nokogiri::XML source
+        puts doc.to_xml
       end
     end
   end


### PR DESCRIPTION


Error in the format of the ossec.conf files and command entries only added on the manager side.

We use the Nokogiri gem to obtain the desired format after using Gyoku.

We substitute the value of "all" for the "server" in the attributes of the ossec.conf files so that it only affects the manager.