### PR TITLE
Fixed bugs in ossec_to_xml

### DIFF
--- a/wazuh/libraries/helpers.rb
+++ b/wazuh/libraries/helpers.rb
@@ -56,9 +56,11 @@ class Chef
       def self.ossec_to_xml(hash)
         require 'gyoku'
         require 'nokogiri'
+        formatted_no_decl = Nokogiri::XML::Node::SaveOptions::FORMAT +
+                            Nokogiri::XML::Node::SaveOptions::NO_DECLARATION
         source= Gyoku.xml object_to_ossec(hash)
         doc = Nokogiri::XML source
-        puts doc.to_xml
+        puts doc.to_xml( save_with:formatted_no_decl )
       end
     end
   end

--- a/wazuh/libraries/helpers.rb
+++ b/wazuh/libraries/helpers.rb
@@ -60,7 +60,7 @@ class Chef
                             Nokogiri::XML::Node::SaveOptions::NO_DECLARATION
         source= Gyoku.xml object_to_ossec(hash)
         doc = Nokogiri::XML source
-        puts doc.to_xml( save_with:formatted_no_decl )
+        doc.to_xml( save_with:formatted_no_decl )
       end
     end
   end


### PR DESCRIPTION
ossec_to_xml didn't work properly. Here're the fixes:
- now it returns the result back from helper
- an XML declaration header broke OSSEC with error message:

```
Starting Wazuh v3.2.1 (maintained by Wazuh Inc.)...
2018/04/23 17:11:59 wazuh-modulesd: CRITICAL: (1226): Error reading XML file '/etc/ossec.conf':  (line 0).
```

Fixed this as well.