### PR TITLE
Require Chef 12.14 and remove yum dep

### DIFF
--- a/wazuh/README.md
+++ b/wazuh/README.md
@@ -9,11 +9,13 @@ Tested on Ubuntu and CentOS, but should work on any Unix/Linux platform supporte
 This cookbook doesn't configure Windows systems yet. For manual agent installation on Windows, check the [documentation](https://documentation.wazuh.com/current/installation-guide/installing-wazuh-agent/wazuh_agent_windows.html)
 
 #### Chef
-- Chef 12+
+- Chef 12.14+
 
 #### Cookbooks
 - apt
-- yum
+- chef-sugar
+- poise-python
+- hostsfile
 
 Attributes
 ----------

--- a/wazuh/metadata.rb
+++ b/wazuh/metadata.rb
@@ -15,10 +15,6 @@ supports 'fedora'
 supports 'debian', '>= 7.0'
 supports 'ubuntu', '>= 12.04'
 
-%w( apt ).each do |pkg|
-  depends pkg
-end
-
 %w( debian ubuntu ).each do |os|
   supports os
 end

--- a/wazuh/metadata.rb
+++ b/wazuh/metadata.rb
@@ -22,7 +22,6 @@ end
 depends 'chef-sugar'
 depends 'apt'
 depends 'poise-python'
-depends 'yum'
 depends 'hostsfile'
 
 issues_url 'https://github.com/wazuh/wazuh-chef/issues'

--- a/wazuh/metadata.rb
+++ b/wazuh/metadata.rb
@@ -25,6 +25,6 @@ depends 'poise-python'
 depends 'yum'
 depends 'hostsfile'
 
-issues_url 'https://github.com/wazuh/wazuh-chef/issues' if respond_to?(:issues_url)
-source_url 'https://github.com/wazuh/wazuh-chef' if respond_to?(:source_url)
-chef_version '>= 12.7' if respond_to?(:chef_version)
+issues_url 'https://github.com/wazuh/wazuh-chef/issues'
+source_url 'https://github.com/wazuh/wazuh-chef'
+chef_version '>= 12.14'

--- a/wazuh_elastic/README.md
+++ b/wazuh_elastic/README.md
@@ -13,11 +13,13 @@ Tested on Ubuntu and CentOS, but should work on any Unix/Linux platform supporte
 This cookbook doesn't configure Windows systems yet. For information on installing Wazuh on Windows, see the [documentation](https://documentation.wazuh.com/current/installation-guide/installing-elastic-stack/index.htmll)
 
 #### Chef
-- Chef 12+
+- Chef 12.14+
 
 #### Cookbooks
 - apt
-- yum
+- chef-sugar
+- poise-python
+- hostsfile
 
 Attributes
 ----------

--- a/wazuh_elastic/metadata.rb
+++ b/wazuh_elastic/metadata.rb
@@ -14,5 +14,8 @@ end
 depends 'chef-sugar'
 depends 'apt'
 depends 'poise-python'
-depends 'yum'
 depends 'hostsfile'
+
+issues_url 'https://github.com/wazuh/wazuh-chef/issues'
+source_url 'https://github.com/wazuh/wazuh-chef'
+chef_version '>= 12.14'

--- a/wazuh_elastic/metadata.rb
+++ b/wazuh_elastic/metadata.rb
@@ -7,10 +7,6 @@ description 'setup Elastic: logstash, elasticsearch and kibana for Wazuh'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.0.2'
 
-%w( apt ).each do |pkg|
-  depends pkg
-end
-
 %w( debian ubuntu ).each do |os|
   supports os
 end

--- a/wazuh_filebeat/README.md
+++ b/wazuh_filebeat/README.md
@@ -17,7 +17,6 @@ This cookbook doesn't configure Windows systems yet. For information on installi
 
 #### Cookbooks
 - apt
-- yum
 
 Attributes
 ----------

--- a/wazuh_filebeat/metadata.rb
+++ b/wazuh_filebeat/metadata.rb
@@ -6,7 +6,6 @@ description      'Installs and configures filebeat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.1'
 
-
 supports 'debian'
 supports 'ubuntu'
 

--- a/wazuh_filebeat/metadata.rb
+++ b/wazuh_filebeat/metadata.rb
@@ -10,3 +10,7 @@ supports 'debian'
 supports 'ubuntu'
 
 depends 'apt'
+
+issues_url 'https://github.com/wazuh/wazuh-chef/issues'
+source_url 'https://github.com/wazuh/wazuh-chef'
+chef_version '>= 12.14'


### PR DESCRIPTION
Remove some old Chef 11 compatibility code in the metadata. Require a mildly current Chef 12 release and yank the yum dep. Remove duplicate apt deps. Cleanup docs for cookbook deps.