### PR TITLE
support agent auth passowrd

### DIFF
--- a/wazuh/recipes/agent.rb
+++ b/wazuh/recipes/agent.rb
@@ -38,6 +38,10 @@ if agent_auth['key'] && File.exist?(agent_auth['key'])
   args << ' -k ' + agent_auth['key']
 end
 
+if agent_auth['password']
+  args << ' -P ' + agent_auth['password']
+end
+
 execute "#{dir}/bin/agent-auth #{args}" do
   timeout 30
   ignore_failure node['ossec']['ignore_failure']


### PR DESCRIPTION
refs: https://documentation.wazuh.com/2.0/user-manual/agents/registering-agents/register-agent-authd.html#use-a-password-to-authorize-agents

Enabled password for agent authentication
