### PR TITLE
Wazuh Chef 3.9.1_6.8.0

### DIFF
--- a/cookbooks/wazuh_elastic/attributes/default.rb
+++ b/cookbooks/wazuh_elastic/attributes/default.rb
@@ -1,3 +1,3 @@
-default['wazuh-elastic']['elastic_stack_version'] = '6.7.2'
-default['wazuh-elastic']['wazuh_app_version'] = "3.9.0_6.7.2"
-default['wazuh-elastic']['extensions_version'] = "v3.9.0"
+default['wazuh-elastic']['elastic_stack_version'] = '6.8.0'
+default['wazuh-elastic']['wazuh_app_version'] = "3.9.1_6.8.0"
+default['wazuh-elastic']['extensions_version'] = "v3.9.1"

--- a/cookbooks/wazuh_elastic/recipes/elasticsearch.rb
+++ b/cookbooks/wazuh_elastic/recipes/elasticsearch.rb
@@ -52,7 +52,7 @@ end
 
 bash 'Elasticsearch_template' do
   code <<-EOH
-  curl https://raw.githubusercontent.com/wazuh/wazuh/#{node['wazuh-elastic']['extensions_version']}/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -X PUT 'http://#{node['wazuh-elastic']['elasticsearch_ip']}:#{node['wazuh-elastic']['elasticsearch_port']}/_template/wazuh' -H 'Content-Type: application/json' -d @-
+  curl https://raw.githubusercontent.com/wazuh/wazuh/#{node['wazuh-elastic']['extensions_version']}/extensions/elasticsearch/6.x/wazuh-template.json | curl -X PUT 'http://#{node['wazuh-elastic']['elasticsearch_ip']}:#{node['wazuh-elastic']['elasticsearch_port']}/_template/wazuh' -H 'Content-Type: application/json' -d @-
   EOH
   not_if "curl -XGET 'http://#{node['wazuh-elastic']['elasticsearch_ip']}:#{node['wazuh-elastic']['elasticsearch_port']}/_template/wazuh' | grep wazuh"
   notifies :restart, "service[elasticsearch]", :immediately

--- a/cookbooks/wazuh_elastic/recipes/logstash.rb
+++ b/cookbooks/wazuh_elastic/recipes/logstash.rb
@@ -15,11 +15,11 @@ when 'rhel'
   end
 end
 
-case node['wazuh-elastic']['logstash_configuration']
+case node['wazuh-elastic']['logstash_configuration'] #
 when "local"
   bash 'Loading logstash local configuration...' do
     code <<-EOF
-    curl -so /etc/logstash/conf.d/01-wazuh.conf https://raw.githubusercontent.com/wazuh/wazuh/#{node['wazuh-elastic']['extensions_version']}/extensions/logstash/01-wazuh-local.conf
+    curl -so /etc/logstash/conf.d/01-wazuh.conf https://github.com/wazuh/wazuh/blob/#{node['wazuh-elastic']['extensions_version']}/extensions/logstash/6.x/01-wazuh-local.conf
     usermod -a -G ossec logstash
     sed -i 's|localhost:9200|'#{node['wazuh-elastic']['elasticsearch_ip']}:#{node['wazuh-elastic']['elasticsearch_port']}'|g' /etc/logstash/conf.d/01-wazuh.conf
     EOF
@@ -28,7 +28,7 @@ when "local"
 when "remote"
   bash 'Loading logstash remote configuration...' do
     code <<-EOF
-    curl -so /etc/logstash/conf.d/01-wazuh.conf https://raw.githubusercontent.com/wazuh/wazuh/#{node['wazuh-elastic']['extensions_version']}/extensions/logstash/01-wazuh-remote.conf 
+    curl -so /etc/logstash/conf.d/01-wazuh.conf https://github.com/wazuh/wazuh/blob/#{node['wazuh-elastic']['extensions_version']}/extensions/logstash/6.x/01-wazuh-local.conf 
     sed -i 's|localhost:9200|'#{node['wazuh-elastic']['elasticsearch_ip']}:#{node['wazuh-elastic']['elasticsearch_port']}'|g' /etc/logstash/conf.d/01-wazuh.conf 
     EOF
   end

--- a/cookbooks/wazuh_elastic/recipes/logstash.rb
+++ b/cookbooks/wazuh_elastic/recipes/logstash.rb
@@ -17,9 +17,9 @@ end
 
 case node['wazuh-elastic']['logstash_configuration'] #
 when "local"
-  bash 'Loading logstash local configuration...' do
+  bash 'Loading logstash local configuration...' do 
     code <<-EOF
-    curl -so /etc/logstash/conf.d/01-wazuh.conf https://github.com/wazuh/wazuh/blob/#{node['wazuh-elastic']['extensions_version']}/extensions/logstash/6.x/01-wazuh-local.conf
+    curl -so /etc/logstash/conf.d/01-wazuh.conf https://raw.githubusercontent.com/wazuh/wazuh/#{node['wazuh-elastic']['extensions_version']}/extensions/logstash/6.x/01-wazuh-local.conf
     usermod -a -G ossec logstash
     sed -i 's|localhost:9200|'#{node['wazuh-elastic']['elasticsearch_ip']}:#{node['wazuh-elastic']['elasticsearch_port']}'|g' /etc/logstash/conf.d/01-wazuh.conf
     EOF
@@ -28,7 +28,7 @@ when "local"
 when "remote"
   bash 'Loading logstash remote configuration...' do
     code <<-EOF
-    curl -so /etc/logstash/conf.d/01-wazuh.conf https://github.com/wazuh/wazuh/blob/#{node['wazuh-elastic']['extensions_version']}/extensions/logstash/6.x/01-wazuh-local.conf 
+    curl -so /etc/logstash/conf.d/01-wazuh.conf https://raw.githubusercontent.com/wazuh/wazuh/#{node['wazuh-elastic']['extensions_version']}/extensions/logstash/6.x/01-wazuh-remote.conf 
     sed -i 's|localhost:9200|'#{node['wazuh-elastic']['elasticsearch_ip']}:#{node['wazuh-elastic']['elasticsearch_port']}'|g' /etc/logstash/conf.d/01-wazuh.conf 
     EOF
   end

--- a/cookbooks/wazuh_filebeat/attributes/default.rb
+++ b/cookbooks/wazuh_filebeat/attributes/default.rb
@@ -8,7 +8,7 @@
 default['filebeat']['elastic_stack_version'] = '6.8.0'
 default['filebeat']['package_name'] = 'filebeat'
 default['filebeat']['service_name'] = 'filebeat'
-default['filebeat']['logstash_servers'] = '127.0.0.1:5000'
+default['filebeat']['logstash_servers'] = ["YOUR_ELASTIC_SERVER_IP:5000"]
 default['filebeat']['timeout'] = 15
 default['filebeat']['config_path'] = '/etc/filebeat/filebeat.yml'
 default['filebeat']['certificate_authorities'] = '/etc/filebeat/logstash_certificate.crt'

--- a/cookbooks/wazuh_filebeat/attributes/default.rb
+++ b/cookbooks/wazuh_filebeat/attributes/default.rb
@@ -5,7 +5,7 @@
 #
 #
 #
-default['filebeat']['elastic_stack_version'] = '6.7.2'
+default['filebeat']['elastic_stack_version'] = '6.8.0'
 default['filebeat']['package_name'] = 'filebeat'
 default['filebeat']['service_name'] = 'filebeat'
 default['filebeat']['logstash_servers'] = 'indexer.wazuh.com:5000'

--- a/cookbooks/wazuh_filebeat/attributes/default.rb
+++ b/cookbooks/wazuh_filebeat/attributes/default.rb
@@ -8,7 +8,7 @@
 default['filebeat']['elastic_stack_version'] = '6.8.0'
 default['filebeat']['package_name'] = 'filebeat'
 default['filebeat']['service_name'] = 'filebeat'
-default['filebeat']['logstash_servers'] = 'indexer.wazuh.com:5000'
+default['filebeat']['logstash_servers'] = '127.0.0.1:5000'
 default['filebeat']['timeout'] = 15
 default['filebeat']['config_path'] = '/etc/filebeat/filebeat.yml'
 default['filebeat']['certificate_authorities'] = '/etc/filebeat/logstash_certificate.crt'


### PR DESCRIPTION
Hi team,

This PR updates chef to use Wazuh 3.9.1 components and ELK components to 6.8.0.

* Bumped Version
* Fixed URLs
* Updated ```['filebeat']['logstash_servers']``` default ip.

Best Regards!
Jose