### PR TITLE
Adapting versions and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Update to Wazuh version 3.9.3_7.2.0
 
 ## Wazuh Chef v3.9.2_7.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Wazuh Chef v3.9.3_7.2.0
+
+### Added
+
+
 ## Wazuh Chef v3.9.2_7.1.1
 
 ### Added

--- a/cookbooks/wazuh_agent/attributes/version.rb
+++ b/cookbooks/wazuh_agent/attributes/version.rb
@@ -1,1 +1,1 @@
-default['wazuh-agent']['version'] = "3.9.2"
+default['wazuh-agent']['version'] = "3.9.3"

--- a/cookbooks/wazuh_elastic/attributes/versions.rb
+++ b/cookbooks/wazuh_elastic/attributes/versions.rb
@@ -1,3 +1,3 @@
-default['wazuh-elastic']['elastic_stack_version'] = '7.1.1'
-default['wazuh-elastic']['wazuh_app_version'] = "3.9.2_7.1.1"
-default['wazuh-elastic']['extensions_version'] = "v3.9.2"
+default['wazuh-elastic']['elastic_stack_version'] = '7.2.0'
+default['wazuh-elastic']['wazuh_app_version'] = "3.9.3_7.2.0"
+default['wazuh-elastic']['extensions_version'] = "v3.9.3"

--- a/cookbooks/wazuh_filebeat/attributes/versions.rb
+++ b/cookbooks/wazuh_filebeat/attributes/versions.rb
@@ -1,4 +1,4 @@
-default['filebeat']['elastic_stack_version'] = '7.1.1'
-default['filebeat']['wazuh_app_version'] = "3.9.2_7.1.1"
-default['filebeat']['extensions_version'] = "v3.9.2"
+default['filebeat']['elastic_stack_version'] = '7.2.0'
+default['filebeat']['wazuh_app_version'] = "3.9.3_7.2.0"
+default['filebeat']['extensions_version'] = "v3.9.3"
 

--- a/cookbooks/wazuh_manager/attributes/versions.rb
+++ b/cookbooks/wazuh_manager/attributes/versions.rb
@@ -1,1 +1,1 @@
-default['wazuh-manager']['version'] = "3.9.2"
+default['wazuh-manager']['version'] = "3.9.3"


### PR DESCRIPTION
Hi team!

This PR represents Bump Version changes for the new release 3.9.3_7.2.0. The applied changes are described as follows:

- Adapting Wazuh components' version, such as manager and agent to 3.9.3
- Adapting Elasticsearch and Kibana version to 7.2.0
- Updated CHANGELOG.md:
```
## Wazuh Chef v3.9.3_7.2.0

### Added
```
Kind regards,

Rshad