### PR TITLE
updated CHANGELOG.md, adapted versions and modified README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Wazuh Chef v3.9.3_6.8.1
+
+### Added
+
+- Update Wazuh to 3.9.3 version.
+
 ## Wazuh Chef v3.9.2_6.8.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Deploy Wazuh platform using Chef cookbooks. Chef recipes are prepared for instal
 
 ## Cookbooks
 
-* [Wazuh Agent ](https://github.com/wazuh/wazuh-chef/tree/v3.9.2_6.8.0/cookbooks/wazuh_agent)
-* [Wazuh Manager and API](https://github.com/wazuh/wazuh-chef/tree/v3.9.2_6.8.0/cookbooks/wazuh_manager)
-* [Elastic Stack (Elasticsearch, Logstash, Kibana)](https://github.com/wazuh/wazuh-chef/tree/v3.9.2_6.8.0/cookbooks/wazuh_elastic)
-* [Filebeat](https://github.com/wazuh/wazuh-chef/tree/v3.9.2_6.8.0/cookbooks/wazuh_filebeat)
+* [Wazuh Agent ](https://github.com/wazuh/wazuh-chef/tree/v3.9.3_6.8.1/cookbooks/wazuh_agent)
+* [Wazuh Manager and API](https://github.com/wazuh/wazuh-chef/tree/v3.9.3_6.8.1/cookbooks/wazuh_manager)
+* [Elastic Stack (Elasticsearch, Logstash, Kibana)](https://github.com/wazuh/wazuh-chef/tree/v3.9.3_6.8.1/cookbooks/wazuh_elastic)
+* [Filebeat](https://github.com/wazuh/wazuh-chef/tree/v3.9.3_6.8.1/cookbooks/wazuh_filebeat)
 
 Each cookbook has its own README.md
 
@@ -20,8 +20,8 @@ Each cookbook has its own README.md
 
 You can find predefined roles for a default installation of Wazuh Agent and Manager in the roles folder.
 
-- [Wazuh Agent Role](https://github.com/wazuh/wazuh-chef/blob/v3.9.2_6.8.0/roles/wazuh_agent.json)
-- [Wazuh Manager Role](https://github.com/wazuh/wazuh-chef/blob/v3.9.2_6.8.0/roles/wazuh_agent.json)
+- [Wazuh Agent Role](https://github.com/wazuh/wazuh-chef/blob/v3.9.3_6.8.1/roles/wazuh_agent.json)
+- [Wazuh Manager Role](https://github.com/wazuh/wazuh-chef/blob/v3.9.3_6.8.1/roles/wazuh_agent.json)
 
 Check roles README for more information about default attributes and how to customize your installation.
 

--- a/cookbooks/wazuh_elastic/attributes/default.rb
+++ b/cookbooks/wazuh_elastic/attributes/default.rb
@@ -1,3 +1,3 @@
-default['wazuh-elastic']['elastic_stack_version'] = '6.8.0'
-default['wazuh-elastic']['wazuh_app_version'] = "3.9.2_6.8.0"
-default['wazuh-elastic']['extensions_version'] = "v3.9.2"
+default['wazuh-elastic']['elastic_stack_version'] = '6.8.1'
+default['wazuh-elastic']['wazuh_app_version'] = "3.9.3_6.8.1"
+default['wazuh-elastic']['extensions_version'] = "v3.9.3"

--- a/cookbooks/wazuh_filebeat/attributes/default.rb
+++ b/cookbooks/wazuh_filebeat/attributes/default.rb
@@ -5,7 +5,7 @@
 #
 #
 #
-default['filebeat']['elastic_stack_version'] = '6.8.0'
+default['filebeat']['elastic_stack_version'] = '6.8.1'
 default['filebeat']['package_name'] = 'filebeat'
 default['filebeat']['service_name'] = 'filebeat'
 default['filebeat']['logstash_servers'] = "YOUR_ELASTIC_SERVER_IP:5000"


### PR DESCRIPTION
Hi team!

This PR represents Bump Version changes for the new release 3.9.3_6.8.1. The applied changes are described as follows:

Adapting Wazuh components' version, such as manager and agent to 3.9.3
Adapting Elasticsearch and Kibana version to 6.8.1
Updated CHANGELOG.md:
```
## Wazuh Puppet v3.9.3_6.8.1

### Added

- Update to Wazuh version 3.9.3
```
Kind regards,

Rshad