### PR TITLE
Fix sensitive

### DIFF
--- a/cookbooks/wazuh_agent/CHANGELOG.md
+++ b/cookbooks/wazuh_agent/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+Fixed agent-auth resource verbosity.
 ## v0.1.0
 1. Bump to wazuh 4.0.1 version
 2. Added suse repository

--- a/cookbooks/wazuh_agent/recipes/agent.rb
+++ b/cookbooks/wazuh_agent/recipes/agent.rb
@@ -89,10 +89,12 @@ if agent_auth['password']
   args << ' -P ' + agent_auth['password']
 end
 
-execute "#{dir}/bin/agent-auth #{args}" do
+execute 'wazuh agent auth' do
+  command "#{dir}/bin/agent-auth #{args}"
   timeout 30
   ignore_failure node['ossec']['ignore_failure']
   only_if { agent_auth['register'] == 'yes' && agent_auth['host'] && !File.size?("#{dir}/etc/client.keys") }
+  sensitive true
 end
 
 include_recipe 'wazuh_agent::common'

--- a/cookbooks/wazuh_agent/recipes/agent.rb
+++ b/cookbooks/wazuh_agent/recipes/agent.rb
@@ -85,10 +85,6 @@ if agent_auth['key'] && File.exist?(agent_auth['key'])
   args << ' -k ' + agent_auth['key']
 end
 
-if agent_auth['password']
-  args << ' -P ' + agent_auth['password']
-end
-
 execute 'wazuh agent auth' do
   command "#{dir}/bin/agent-auth #{args}"
   timeout 30


### PR DESCRIPTION
_This PR was originally opened by @axl89_


Fixes `wazuh agent auth` resource leaking sensitive data and removes duplicated code:

```
  * execute[/var/ossec/bin/agent-auth -m 1.2.3.4 -p 1515 -A hostname -P xxxxxxxxx -P xxxxxxxxx] action run[2020-12-18T13:08:31+00:00] INFO: Processing execute[/var/ossec/bin/agent-auth -m 1.2.3.4 -p 1515 -A hostname -P xxxxxxxxx -P xxxxxxxxx] action run (wazuh_agent::agent line 92)

    [execute] 2020/12/18 13:08:31 agent-auth: INFO: Started (pid: 15855).
              2020/12/18 13:08:31 agent-auth: INFO: Connected to 1.2.3.4:1515
              2020/12/18 13:08:31 agent-auth: INFO: Using agent name as: hostname
              2020/12/18 13:08:31 agent-auth: INFO: Send request to manager. Waiting for reply.
              2020/12/18 13:08:31 agent-auth: INFO: Received response with agent key
              2020/12/18 13:08:31 agent-auth: INFO: Valid key created. Finished.
              2020/12/18 13:08:31 agent-auth: INFO: Connection closed.
[2020-12-18T13:08:31+00:00] INFO: execute[/var/ossec/bin/agent-auth -m 1.2.3.4 -p 1515 -A hostname -P xxxxxxxxx -P xxxxxxxxx] ran successfully
    - execute /var/ossec/bin/agent-auth -m 1.2.3.4 -p 1515 -A hostname -P xxxxxxxxx -P xxxxxxxxx
```