### PR TITLE
Update API config with the new logs format param

### DIFF
--- a/cookbooks/wazuh_manager/templates/default/api.yaml.erb
+++ b/cookbooks/wazuh_manager/templates/default/api.yaml.erb
@@ -5,9 +5,11 @@ port: <%= @port %>
 
 # Logging configuration
 # Values for API log level: disabled, info, warning, error, debug, debug2 (each level includes the previous level).
+# Values for API log format: 'plain', 'json', 'plain,json', 'json,plain'
 logs:
   level: "info"
   path: "logs/api.log"
+  format: "plain"
 
 # Cross-origin resource sharing: https://github.com/aio-libs/aiohttp-cors#usage
 cors:


### PR DESCRIPTION
This PR closes #152 .

In this pull request, I have added the new API logs `format` parameter to the API configuration template.